### PR TITLE
Bug fix: added "volatile" qualifier to "sig_atomic_t received_signal"

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,23 @@ You can start a VM by running the `run.sh` script in the VM folder. Each VM is a
 
 Compile the kernel module by running `make` in the `module` folder, then copy the `plutonium-dbg.ko` file and any of the Python scripts you wish to use to your target machine.
 
-*You can also compile plutonium-dbg for your host system by replacing the path to the kernel in `module/Makefile` to `/lib/modules/$(shell uname -r)/build`. This requires the development headers for your kernel version, but allows you to avoid using QEMU. Note that plutonium-dbg is not yet stable; do not do this outside of a virtual machine unless you are happy to accidentally crash your system.*
+#### Compilation for host system
+
+You can also compile plutonium-dbg for your host system by replacing the path to the kernel in `module/Makefile` to `/lib/modules/$(shell uname -r)/build` (just uncomment the corresponding line). This requires the development headers for your kernel version, but allows you to avoid using QEMU. Note that plutonium-dbg is not yet stable; do not do this outside of a virtual machine unless you are happy to accidentally crash your system.
+
+On a Debian-based distro (e.g. Ubuntu), you may install the development headers for your kernel version with:
+
+```shell
+sudo apt-get install linux-headers-$(uname -r)
+```
+
+On a Red Hat'ish distro (e.g. Fedora, RHEL, CentOS), you may do it with:
+
+```shell
+sudo yum install kernel-devel
+```
+
+Unfortunately, plutonium-dbg currently does not actually build with RHEL7'ish (e.g., CentOS 7) kernel headers - pull requests to make this actually work are welcome.
 
 ## Contributing
 

--- a/clients/launch.c
+++ b/clients/launch.c
@@ -3,9 +3,9 @@
 #include <stdio.h>
 #include <unistd.h>
 
-sig_atomic_t received_signal = 0;
+volatile sig_atomic_t received_signal = 0;
 
-void handle_sigusr1(int signal)
+static void handle_sigusr1(int signal)
 {
     received_signal = (signal == SIGUSR1);
 }
@@ -25,5 +25,5 @@ int main(int argc, char *argv[], char *envp[])
     while (!received_signal) usleep(50000);
 
     // Launch target
-	execvpe(argv[1], &argv[1], envp);
+    execvpe(argv[1], &argv[1], envp);
 }

--- a/module/Makefile
+++ b/module/Makefile
@@ -1,12 +1,15 @@
 obj-m += plutonium-dbg.o
 
+KERNEL=../setup/linux
+#KERNEL=/lib/modules/$(shell uname -r)/build
+
 .PHONY: all debug clean
 
 all:
-	make -C ../setup/linux M=$(PWD) modules
+	make -C $(KERNEL) M=$(PWD) modules
 
 debug:
-	make CFLAGS_plutonium-dbg.o=-DMOD_DEBUG_ENABLE_TRACE -C ../setup/linux M=$(PWD) modules
+	make CFLAGS_plutonium-dbg.o=-DMOD_DEBUG_ENABLE_TRACE -C $(KERNEL) M=$(PWD) modules
 
 clean:
-	make -C ../setup/linux M=$(PWD) clean
+	make -C $(KERNEL) M=$(PWD) clean


### PR DESCRIPTION
Bug fix: added "volatile" qualifier to "sig_atomic_t received_signal".

Cleanups: added "static" to "void handle_sigusr1()" since it's not referenced from outside of this translation unit, corrected the indentation (the use of a tab was inconsistent).

A first step towards being friendlier to "Compilation for host system".