### PR TITLE
Added access controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,16 @@ dbg.continue_thread(pid)
 
 #### GDB
 
-While the kernel module is loaded, you can use our GDB remote server to interact with plutonium-dbg through a GDB client. Simply start the program by launching `gdbserver.py <program>`.
+While the kernel module is loaded, you can use our GDB remote server to interact with plutonium-dbg through a GDB client.
+Simply start the program by launching either `gdbserver.py --tcp <port> <program>` or `gdbserver.py --unix <socket_name> <program>`.
 
 To connect to a GDB server running on the VM, use the following commands from  your host GDB (this allows you to keep any of your custom settings, including plugins such as [pwndbg](https://github.com/pwndbg/pwndbg)):
 
-    set target-architecture i386:x86_64
-    target remote localhost:1337
+First set the architecture you want to debug with e.g. `set target-architecture i386:x86_64`. Once we implement the `vFile` extensions, this will no longer be necessary.
+
+Then, depending on how you started the server, connect either via TCP with `target remote localhost:1337` or through a Unix Socket with `target remote | socat UNIX:socket_name -`.
+
+Note that socat needs to be installed for the latter option.
 
 ## Setup
 

--- a/module/plutonium-dbg.c
+++ b/module/plutonium-dbg.c
@@ -92,6 +92,85 @@ static struct kprobe signal_probe;
 
 
 
+/* Access control */
+
+/**
+ * check_access - Checks whether the current process is allowed to debug the target
+ * @target: The target thread or process
+ *
+ * Returns -ESRCH if the task does not exist.
+ * Returns -EPERM if access is denied.
+ * Returns 0 if access is granted.
+ *
+ * Access is granted if (a) the requesting thread is in the same thread group as
+ * the target, (b) the requesting process already has the permission to ptrace
+ * arbitrary processes (CAP_SYS_PTRACE), or (c)
+ *  - the requesting process' EUID equals the target's EUID, RUID, and SUID, and
+ *  - the requesting process' EGID equals the target's EGID, RGID, and SGID.
+ * For (c), we check the target's RUID (to ensure that processes which drop
+ * privileges can only be debugged by their owner or someone allowed to
+ * impersonate that owner), EUID (to ensure that processes with elevated
+ * privileges can only be debugged by someone with at least equivalent
+ * privileges), and SUID (to avoid any nasty surprises). This means that the
+ * "user history" (which user started the process, and what user it switched to)
+ * needs to be replicated exactly by the requesting process. On multi-user
+ * systems, this ensures that a privilege-dropping process owned by A cannot
+ * simply be debugged by a privilege-dropping process owned by B.
+ *
+ * For (c), we could additionally check whether ptrace access was limited by a
+ * kernel security module such as Yama (via yama.ptrace_scope) via
+ * security_ptrace_access_check, but the relevant functions are not exported by
+ * the kernel. We may revisit enabling this option to enhance security.
+ */
+static int check_access(pid_t target)
+{
+	int                 uid_check;
+	int                 gid_check;
+	int                 flags;
+	bool                capable;
+	struct task_struct *task;
+	const struct cred  *t_cred;
+	kuid_t              r_euid;
+	kgid_t              r_egid;
+
+	/* Get the task */
+	rcu_read_lock();
+	task = pid_task(find_vpid(target), PIDTYPE_PID);
+	if (task == NULL)
+		cleanup_and_return(-ESRCH, rcu_read_unlock());
+	get_task_struct(task);
+	rcu_read_unlock();
+
+	t_cred = __task_cred(task);
+
+	/* Check thread groups */
+	if (same_thread_group(current, task))
+		cleanup_and_return(0, put_task_struct(task));
+
+	/* Check global ptrace capability */
+	flags = current->flags;
+	capable = ns_capable(t_cred->user_ns, CAP_SYS_PTRACE);
+	current->flags = flags; /* Restore flags, because ns_capable sets PF_SUPERPRIV */
+
+	if (capable)
+		cleanup_and_return(0, put_task_struct(task));
+
+	/* Manually check IDs */
+	r_euid = current_euid();
+	r_egid = current_egid();
+
+	uid_check = uid_eq(r_euid, t_cred->euid) && uid_eq(r_euid, t_cred->uid) && uid_eq(r_euid, t_cred->suid);
+	gid_check = gid_eq(r_egid, t_cred->egid) && gid_eq(r_egid, t_cred->gid) && gid_eq(r_egid, t_cred->sgid);
+	if (uid_check && gid_check)
+		cleanup_and_return(0, put_task_struct(task));
+
+	/* By default, deny access */
+	put_task_struct(task);
+	return -EPERM;
+}
+
+
+
 /* Utility functions */
 
 /**
@@ -1747,6 +1826,9 @@ static long on_ioctl(struct file *fp, unsigned int command, unsigned long argume
 		arg_tid_or_tgid = (struct ioctl_tid_or_tgid *) argument;
 		TRACE("ioctl: continue(%d, %d) from %d\n", arg_tid_or_tgid->type, arg_tid_or_tgid->id, current->pid);
 
+		if ((result = check_access(arg_tid_or_tgid->id)))
+			return result;
+
 		mutex_lock(&data_mutex);
 		if (arg_tid_or_tgid->type == TID) {
 			result = __unlock_thread(current->tgid, arg_tid_or_tgid->id);
@@ -1763,6 +1845,9 @@ static long on_ioctl(struct file *fp, unsigned int command, unsigned long argume
 		arg_tid_or_tgid = (struct ioctl_tid_or_tgid *) argument;
 		TRACE("ioctl: suspend(%d, %d) from %d\n", arg_tid_or_tgid->type, arg_tid_or_tgid->id, current->pid);
 
+		if ((result = check_access(arg_tid_or_tgid->id)))
+			return result;
+
 		mutex_lock(&data_mutex);
 		if (arg_tid_or_tgid->type == TID) {
 			result = __lock_thread(current->tgid, arg_tid_or_tgid->id, SUSPEND_EXPLICIT);
@@ -1778,16 +1863,22 @@ static long on_ioctl(struct file *fp, unsigned int command, unsigned long argume
 	case IOCTL_INSTALL_BREAKPOINT:
 		arg_breakpoint = (struct ioctl_breakpoint_identifier *) argument;
 		TRACE("ioctl: install_breakpoint(%d, %lx) from %d\n", arg_breakpoint->target, arg_breakpoint->address, current->pid);
+		if ((result = check_access(arg_breakpoint->target)))
+			return result;
 		return install_breakpoint(current->tgid, arg_breakpoint->target, arg_breakpoint->address);
 
 	case IOCTL_REMOVE_BREAKPOINT:
 		arg_breakpoint = (struct ioctl_breakpoint_identifier *) argument;
 		TRACE("ioctl: remove_breakpoint(%d, %lx) from %d\n", arg_breakpoint->target, arg_breakpoint->address, current->pid);
+		if ((result = check_access(arg_breakpoint->target)))
+			return result;
 		return remove_breakpoint(current->tgid, arg_breakpoint->target, arg_breakpoint->address);
 
 	case IOCTL_SET_STEP:
 		arg_flag = (struct ioctl_flag *) argument;
 		TRACE("ioctl: set_step(%d, %d) from %d\n", arg_flag->target, arg_flag->value, current->pid);
+		if ((result = check_access(arg_flag->target)))
+			return result;
 		if (arg_flag->value)
 			return install_step_listener(current->tgid, arg_flag->target);
 		else
@@ -1795,12 +1886,17 @@ static long on_ioctl(struct file *fp, unsigned int command, unsigned long argume
 
 	case IOCTL_SET_EVENT_MASK:
 		arg_flag = (struct ioctl_flag *) argument;
+		if ((result = check_access(arg_flag->target)))
+			return result;
 		TRACE("ioctl: set_event_mask(%d, %d) from %d\n", arg_flag->target, arg_flag->value, current->pid);
 		return set_event_mask(current->tgid, arg_flag->target, arg_flag->value);
 
 	case IOCTL_WAIT:
 		arg_enumeration = (struct ioctl_enumeration *) argument;
 		TRACE("ioctl: wait() from %d\n", current->pid);
+
+		if ((result = check_access(arg_enumeration->target)))
+			return result;
 
 		for (;;) {
 			/* Check whether to suspend */
@@ -1827,6 +1923,9 @@ static long on_ioctl(struct file *fp, unsigned int command, unsigned long argume
 		arg_enumeration = (struct ioctl_enumeration *) argument;
 		TRACE("ioctl: wait_for(%d) from %d\n", arg_enumeration->target, current->pid);
 
+		if ((result = check_access(arg_enumeration->target)))
+			return result;
+
 		for (;;) {
 			/* Check whether to suspend */
 			mutex_lock(&data_mutex);
@@ -1852,36 +1951,50 @@ static long on_ioctl(struct file *fp, unsigned int command, unsigned long argume
 	case IOCTL_STATUS:
 		arg_enumeration = (struct ioctl_enumeration *) argument;
 		TRACE("ioctl: read_status(%d) from %d\n", arg_enumeration->target, current->pid);
+		if ((result = check_access(arg_enumeration->target)))
+			return result;
 		return read_status(current->tgid, arg_enumeration);
 
 	case IOCTL_ENUMERATE_THREADS:
 		arg_enumeration = (struct ioctl_enumeration *) argument;
 		TRACE("ioctl: enumerate_threads(%d) from %d\n", arg_enumeration->target, current->pid);
+		if ((result = check_access(arg_enumeration->target)))
+			return result;
 		return enumerate_threads(arg_enumeration);
 
 	case IOCTL_SUSPEND_REASON:
 		arg_flag = (struct ioctl_flag *) argument;
 		TRACE("ioctl: suspend_reason(%d) from %d\n", arg_flag->target, current->pid);
+		if ((result = check_access(arg_flag->target)))
+			return result;
 		return suspend_reason(current->tgid, arg_flag);
 
 	case IOCTL_READ_MEMORY:
 		arg_cpy = (struct ioctl_cpy *) argument;
 		//TRACE("ioctl: read_memory(%d, %lx, %ld) from %d\n", arg_cpy->target, arg_cpy->which, arg_cpy->size, current->pid);
+		if ((result = check_access(arg_cpy->target)))
+			return result;
 		return copy_memory(arg_cpy->target, arg_cpy->which, arg_cpy->size, (char __user *) arg_cpy->buffer, COPY_TO_USERSPACE);
 
 	case IOCTL_WRITE_MEMORY:
 		arg_cpy = (struct ioctl_cpy *) argument;
 		TRACE("ioctl: write_memory(%d, %lx, %ld) from %d\n", arg_cpy->target, arg_cpy->which, arg_cpy->size, current->pid);
+		if ((result = check_access(arg_cpy->target)))
+			return result;
 		return copy_memory(arg_cpy->target, arg_cpy->which, arg_cpy->size, (char __user *) arg_cpy->buffer, COPY_FROM_USERSPACE);
 
 	case IOCTL_READ_REGISTERS:
 		arg_cpy = (struct ioctl_cpy *) argument;
 		TRACE("ioctl: read_registers(%d, %lx) from %d\n", arg_cpy->target, arg_cpy->which, current->pid);
+		if ((result = check_access(arg_cpy->target)))
+			return result;
 		return copy_registers(arg_cpy->target, arg_cpy->which, &arg_cpy->size, (char __user *) arg_cpy->buffer, COPY_TO_USERSPACE);
 
 	case IOCTL_WRITE_REGISTERS:
 		arg_cpy = (struct ioctl_cpy *) argument;
 		TRACE("ioctl: write_registers(%d, %lx) from %d\n", arg_cpy->target, arg_cpy->which, current->pid);
+		if ((result = check_access(arg_cpy->target)))
+			return result;
 		return copy_registers(arg_cpy->target, arg_cpy->which, &arg_cpy->size, (char __user *) arg_cpy->buffer, COPY_FROM_USERSPACE);
 
 	default:
@@ -2162,6 +2275,13 @@ static struct cdev   device;
 #define DEVICE_FIRST_MINOR 0
 #define DEVICE_MINOR_COUNT 1
 
+static char *device_node(struct device *dev, umode_t *mode)
+{
+	if (mode != NULL)
+		*mode = 0666;
+	return NULL;
+}
+
 
 
 /* Module initialization and cleanup */
@@ -2202,6 +2322,7 @@ static int __init initialize(void)
 		unregister_chrdev_region(first_device, DEVICE_MINOR_COUNT);
 		return -ENODEV;
 	}
+	device_class->devnode = device_node; /* This will set the device to mode 0666 (-rw-rw-rw-) */
 	if (device_create(device_class, NULL, first_device, NULL, DEVICE_FILE_NAME) == NULL) {
 		class_destroy(device_class);
 		unregister_chrdev_region(first_device, DEVICE_MINOR_COUNT);

--- a/module/plutonium-dbg.c
+++ b/module/plutonium-dbg.c
@@ -150,7 +150,8 @@ static int check_access(pid_t target)
 	/* Check global ptrace capability */
 	flags = current->flags;
 	capable = ns_capable(t_cred->user_ns, CAP_SYS_PTRACE);
-	current->flags = flags; /* Restore flags, because ns_capable sets PF_SUPERPRIV */
+	if (!(flags & PF_SUPERPRIV))
+		current->flags &= ~PF_SUPERPRIV; /* ns_capable sets PF_SUPERPRIV, reset the state of that flag */
 
 	if (capable)
 		cleanup_and_return(0, put_task_struct(task));

--- a/module/plutonium-dbg.c
+++ b/module/plutonium-dbg.c
@@ -1929,9 +1929,6 @@ static long on_ioctl(struct file *fp, unsigned int command, unsigned long argume
 		arg_enumeration = (struct ioctl_enumeration *) argument;
 		TRACE("ioctl: wait() from %d\n", current->pid);
 
-		if ((result = check_access(arg_enumeration->target)))
-			return result;
-
 		for (;;) {
 			/* Check whether to suspend */
 			mutex_lock(&data_mutex);
@@ -2032,6 +2029,8 @@ static long on_ioctl(struct file *fp, unsigned int command, unsigned long argume
 	case IOCTL_READ_AUXV:
 		arg_cpy = (struct ioctl_cpy *) argument;
 		//TRACE("ioctl: read_auxv(%d, %lx, %ld) from %d\n", arg_cpy->target, arg_cpy->which, arg_cpy->size, current->pid);
+		if ((result = check_access(arg_cpy->target)))
+			return result;
 		return read_auxv(arg_cpy->target, arg_cpy->size, (char __user *) arg_cpy->buffer);
 
 	case IOCTL_WRITE_MEMORY:


### PR DESCRIPTION
This pull request makes `/dev/debugging` world-writable, but enforces more granular access restrictions on a per-target basis, modeled after what `ptrace` enforces on a standard system.
Unfortunately, the hooks for kernel security modules (e.g. Yama's ptrace_scope restriction) are not exported by the kernel - if you find a way to call those, we should add it to `check_access`.