### PR TITLE
Signal handling

### DIFF
--- a/clients/plutonium_dbg.py
+++ b/clients/plutonium_dbg.py
@@ -79,7 +79,7 @@ class commands:
     cmd_remove_bp      = ioctl(ord("@"), 11, ioctl.W, ctypes.sizeof(messages.ioctl_breakpoint_identifier))
     cmd_set_step       = ioctl(ord("@"), 20, ioctl.W, ctypes.sizeof(messages.ioctl_flag))
     cmd_set_event_mask = ioctl(ord("@"), 30, ioctl.W, ctypes.sizeof(messages.ioctl_flag))
-    cmd_cancel_signal  = ioctl(ord("@"), 40, ioctl.W, ctypes.sizeof(messages.ioctl_flag))
+    cmd_cancel_signal  = ioctl(ord("@"), 40, ioctl.W, ctypes.sizeof(messages.ioctl_tid_or_tgid))
     cmd_wait           = ioctl(ord("@"),  0, ioctl.RW, ctypes.sizeof(messages.ioctl_enumeration))
     cmd_wait_for       = ioctl(ord("@"),  1, ioctl.RW, ctypes.sizeof(messages.ioctl_enumeration))
     cmd_events         = ioctl(ord("@"),  2, ioctl.RW, ctypes.sizeof(messages.ioctl_enumeration))
@@ -248,7 +248,6 @@ class debugger:
         buf = ctypes.create_string_buffer(bits)
         info = messages.ioctl_cpy(tid, request_type, ctypes.c_void_p(ctypes.addressof(buf)), len(bits))
         commands.cmd_write_regs.send(self.device, info)
-    def cancel_signal(self, tid, signal):
-        info = messages.ioctl_flag(tid, signal);
-        result = commands.cmd_cancel_signal.send(self.device, info)
-        return {0: False, 1: True}[result] # This looks hacky, but is just there to error out if the result is not 0 or 1
+    def cancel_signal(self, tid):
+        info = messages.ioctl_tid_or_tgid(tid, 0)
+        commands.cmd_cancel_signal.send(self.device, info)

--- a/module/Makefile
+++ b/module/Makefile
@@ -11,5 +11,8 @@ all:
 debug:
 	make CFLAGS_plutonium-dbg.o="-g -DMOD_DEBUG_ENABLE_TRACE" -C $(KERNEL) M=$(PWD) modules
 
+mutexdebug:
+	make CFLAGS_plutonium-dbg.o="-g -DMOD_DEBUG_ENABLE_TRACE -DMOD_DEBUG_ENABLE_MUTEX_TRACE" -C $(KERNEL) M=$(PWD) modules
+
 clean:
 	make -C $(KERNEL) M=$(PWD) clean

--- a/module/types.h
+++ b/module/types.h
@@ -169,6 +169,7 @@ struct event {
 	union event_data {
 		int suspension_reason; /* EVENT_SUSPEND */
 		int exit_code;         /* EVENT_EXIT */
+		int signal;            /* EVENT_SIGNAL */
 
 		/* EVENT_CLONE */
 		struct {
@@ -192,12 +193,14 @@ struct event {
 #define SUSPEND_ON_EXIT        4
 #define SUSPEND_ON_CLONE       5
 #define SUSPEND_ON_EXEC        6
+#define SUSPEND_ON_SIGNAL      7
 
 /** Event types */
 #define EVENT_SUSPEND     (1 << 0)
 #define EVENT_EXIT        (1 << 1)
 #define EVENT_CLONE       (1 << 2)
 #define EVENT_EXEC        (1 << 3)
+#define EVENT_SIGNAL      (1 << 4)
 
 
 


### PR DESCRIPTION
A new event type `EVENT_SIGNAL` is sent whenever a debugged process receives a signal (when enabled in the event mask). If a process is suspended on a signal (`SUSPEND_ON_SIGNAL`), issuing the `cancel_signal` command will stop the signal from being delivered to the process. Note that this is a destructive (but idempotent) operation; issuing the command from multiple debuggers should not result in errors.