### PR TITLE
Language bindings for C and C++

### DIFF
--- a/clients/plutonium-dbg.c
+++ b/clients/plutonium-dbg.c
@@ -1,0 +1,156 @@
+#include "plutonium-dbg.h"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int PLUTONIUM_DBG_NAME(open_debugger)(void)
+{
+	return open("/dev/debugging", O_RDONLY | O_CLOEXEC);
+}
+
+void PLUTONIUM_DBG_NAME(close_debugger)(int fd)
+{
+	close(fd);
+}
+
+int PLUTONIUM_DBG_NAME(continue_thread)(int fd, pid_t tid)
+{
+	struct ioctl_tid_or_tgid argument = { tid, TID };
+	return ioctl(fd, IOCTL_CONTINUE, (char *) &argument);
+}
+
+int PLUTONIUM_DBG_NAME(continue_process)(int fd, pid_t tgid)
+{
+	struct ioctl_tid_or_tgid argument = { tgid, TGID };
+	return ioctl(fd, IOCTL_CONTINUE, (char *) &argument);
+}
+
+int PLUTONIUM_DBG_NAME(suspend_thread)(int fd, pid_t tid)
+{
+	struct ioctl_tid_or_tgid argument = { tid, TID };
+	return ioctl(fd, IOCTL_SUSPEND, (char *) &argument);
+}
+
+int PLUTONIUM_DBG_NAME(suspend_process)(int fd, pid_t tgid)
+{
+	struct ioctl_tid_or_tgid argument = { tgid, TGID };
+	return ioctl(fd, IOCTL_SUSPEND, (char *) &argument);
+}
+
+int PLUTONIUM_DBG_NAME(install_breakpoint)(int fd, pid_t tgid, addr_t address)
+{
+	struct ioctl_breakpoint_identifier argument = { tgid, address };
+	return ioctl(fd, IOCTL_INSTALL_BREAKPOINT, (char *) &argument);
+}
+
+int PLUTONIUM_DBG_NAME(remove_breakpoint)(int fd, pid_t tgid, addr_t address)
+{
+	struct ioctl_breakpoint_identifier argument = { tgid, address };
+	return ioctl(fd, IOCTL_REMOVE_BREAKPOINT, (char *) &argument);
+}
+
+int PLUTONIUM_DBG_NAME(thread_set_stepping)(int fd, pid_t tid, bool step)
+{
+	struct ioctl_flag argument = { tid, step };
+	return ioctl(fd, IOCTL_SET_STEP, (char *) &argument);
+}
+
+int PLUTONIUM_DBG_NAME(set_event_mask)(int fd, pid_t tgid, int mask)
+{
+	struct ioctl_flag argument = { tgid, mask };
+	return ioctl(fd, IOCTL_SET_EVENT_MASK, (char *) &argument);
+}
+
+ssize_t PLUTONIUM_DBG_NAME(wait)(int fd, struct ioctl_event *event_buffer, size_t buffer_size)
+{
+	struct ioctl_enumeration argument = { 0, (addr_t) event_buffer, buffer_size, 0 };
+	int error = ioctl(fd, IOCTL_WAIT, (char *) &argument);
+	if (error < 0)
+		return error;
+	return argument.size;
+}
+
+ssize_t PLUTONIUM_DBG_NAME(wait_for)(int fd, pid_t tid, struct ioctl_event *event_buffer, size_t buffer_size)
+{
+	struct ioctl_enumeration argument = { tid, (addr_t) event_buffer, buffer_size, 0 };
+	int error = ioctl(fd, IOCTL_WAIT_FOR, (char *) &argument);
+	if (error < 0)
+		return error;
+	return argument.size;
+}
+
+ssize_t PLUTONIUM_DBG_NAME(events)(int fd, struct ioctl_event *event_buffer, size_t buffer_size)
+{
+	struct ioctl_enumeration argument = { 0, (addr_t) event_buffer, buffer_size, 0 };
+	int error = ioctl(fd, IOCTL_EVENTS, (char *) &argument);
+	if (error < 0)
+		return error;
+	return argument.size;
+}
+
+ssize_t PLUTONIUM_DBG_NAME(status)(int fd, pid_t *tid_buffer, size_t buffer_size)
+{
+	struct ioctl_enumeration argument = { 0, (addr_t) tid_buffer, buffer_size, 0 };
+	int error = ioctl(fd, IOCTL_STATUS, (char *) &argument);
+	if (error < 0)
+		return error;
+	return argument.size;
+}
+
+ssize_t PLUTONIUM_DBG_NAME(enumerate_threads)(int fd, pid_t tgid, pid_t *tid_buffer, size_t buffer_size)
+{
+	struct ioctl_enumeration argument = { tgid, (addr_t) tid_buffer, buffer_size, 0 };
+	int error = ioctl(fd, IOCTL_STATUS, (char *) &argument);
+	if (error < 0)
+		return error;
+	return argument.size;
+}
+
+int PLUTONIUM_DBG_NAME(suspension_reason)(int fd, pid_t tid)
+{
+	struct ioctl_flag argument = { tid, 0 };
+	int error = ioctl(fd, IOCTL_SUSPEND_REASON, (char *) &argument);
+	if (error < 0)
+		return error;
+	return argument.value;
+}
+
+int PLUTONIUM_DBG_NAME(read_memory)(int fd, pid_t tgid, addr_t address, unsigned char *buffer, size_t size)
+{
+	struct ioctl_cpy argument = { tgid, address, (addr_t) buffer, size };
+	return ioctl(fd, IOCTL_READ_MEMORY, (char *) &argument);
+}
+
+int PLUTONIUM_DBG_NAME(write_memory)(int fd, pid_t tgid, addr_t address, const unsigned char *buffer, size_t size)
+{
+	struct ioctl_cpy argument = { tgid, address, (addr_t) buffer, size };
+	return ioctl(fd, IOCTL_WRITE_MEMORY, (char *) &argument);
+}
+
+ssize_t PLUTONIUM_DBG_NAME(read_registers)(int fd, pid_t tid, int request_type, unsigned char *buffer, size_t size)
+{
+	struct ioctl_cpy argument = { tid, request_type, (addr_t) buffer, size };
+	int error = ioctl(fd, IOCTL_READ_REGISTERS, (char *) &argument);
+	if (error < 0)
+		return error;
+	return argument.size;
+}
+
+int PLUTONIUM_DBG_NAME(write_registers)(int fd, pid_t tid, int request_type, const unsigned char *buffer, size_t size)
+{
+	struct ioctl_cpy argument = { tid, request_type, (addr_t) buffer, size };
+	return ioctl(fd, IOCTL_READ_REGISTERS, (char *) &argument);
+}
+
+int PLUTONIUM_DBG_NAME(read_auxv)(int fd, pid_t tid, unsigned char *buffer, size_t size)
+{
+	struct ioctl_cpy argument = { tid, 0, (addr_t) buffer, size };
+	return ioctl(fd, IOCTL_READ_AUXV, (char *) &argument);
+}
+
+int PLUTONIUM_DBG_NAME(cancel_signal)(int fd, pid_t tid)
+{
+	struct ioctl_tid_or_tgid argument = { tid, TID };
+	return ioctl(fd, IOCTL_CANCEL_SIGNAL, (char *) &argument);
+}

--- a/clients/plutonium-dbg.cpp
+++ b/clients/plutonium-dbg.cpp
@@ -1,0 +1,180 @@
+#include "plutonium-dbg.hpp"
+
+extern "C"
+{
+    #include <fcntl.h>
+    #include <unistd.h>
+}
+
+namespace
+{
+	// Don't export any of this
+	// Open the device on loading, and close on unloading.
+	struct fd_guard
+	{
+		fd_guard(const char *path)
+			: fd { open(path, O_RDWR | O_CLOEXEC | O_NONBLOCK) }
+		{}
+		~fd_guard() { close(fd); }
+
+		int fd;
+	};
+
+	fd_guard global_guard { PLUTONIUM_DBG_PATH };
+
+	// Abstract the file descriptor away
+	template <typename T>
+	int send_ioctl(unsigned long request, T *argument)
+	{
+		return ::ioctl(
+			::global_guard.fd,
+			request,
+			reinterpret_cast<char *>(argument)
+		);
+	}
+}
+
+// Actual functionality
+namespace PLUTONIUM_DBG_NS
+{
+	int continue_thread(pid_t tid)
+	{
+		ioctl_tid_or_tgid argument { tid, ioctl_tid_or_tgid::TID };
+		return ::send_ioctl(IOCTL_CONTINUE, &argument);
+	}
+
+	int continue_process(pid_t tgid)
+	{
+		ioctl_tid_or_tgid argument { tgid, ioctl_tid_or_tgid::TGID };
+		return ::send_ioctl(IOCTL_CONTINUE, &argument);
+	}
+
+	int suspend_thread(pid_t tid)
+	{
+		ioctl_tid_or_tgid argument { tid, ioctl_tid_or_tgid::TID };
+		return ::send_ioctl(IOCTL_SUSPEND, &argument);
+	}
+
+	int suspend_process(pid_t tgid)
+	{
+		ioctl_tid_or_tgid argument { tgid, ioctl_tid_or_tgid::TGID };
+		return ::send_ioctl(IOCTL_SUSPEND, &argument);
+	}
+
+	int install_breakpoint(pid_t tgid, addr_t address)
+	{
+		ioctl_breakpoint_identifier argument { tgid, address };
+		return ::send_ioctl(IOCTL_INSTALL_BREAKPOINT, &argument);
+	}
+
+	int remove_breakpoint(pid_t tgid, addr_t address)
+	{
+		ioctl_breakpoint_identifier argument { tgid, address };
+		return ::send_ioctl(IOCTL_REMOVE_BREAKPOINT, &argument);
+	}
+
+	int thread_set_stepping(pid_t tid, bool step)
+	{
+		ioctl_flag argument { tid, step };
+		return ::send_ioctl(IOCTL_SET_STEP, &argument);
+	}
+
+	int set_event_mask(pid_t tgid, int mask)
+	{
+		ioctl_flag argument { tgid, mask };
+		return ::send_ioctl(IOCTL_SET_EVENT_MASK, &argument);
+	}
+
+	ssize_t wait(ioctl_event *event_buffer, size_t buffer_size)
+	{
+		ioctl_enumeration argument { 0, reinterpret_cast<addr_t>(event_buffer), buffer_size, 0 };
+		int error = ::send_ioctl(IOCTL_WAIT, &argument);
+		if (error < 0)
+			return error;
+		return argument.size;
+	}
+
+	ssize_t wait_for(pid_t tid, ioctl_event *event_buffer, size_t buffer_size)
+	{
+		ioctl_enumeration argument { tid, reinterpret_cast<addr_t>(event_buffer), buffer_size, 0 };
+		int error = ::send_ioctl(IOCTL_WAIT_FOR, &argument);
+		if (error < 0)
+			return error;
+		return argument.size;
+	}
+
+	ssize_t events(ioctl_event *event_buffer, size_t buffer_size)
+	{
+		ioctl_enumeration argument { 0, reinterpret_cast<addr_t>(event_buffer), buffer_size, 0 };
+		int error = ::send_ioctl(IOCTL_EVENTS, &argument);
+		if (error < 0)
+			return error;
+		return argument.size;
+	}
+
+	ssize_t status(pid_t *tid_buffer, size_t buffer_size)
+	{
+		ioctl_enumeration argument { 0, reinterpret_cast<addr_t>(tid_buffer), buffer_size, 0 };
+		int error = ::send_ioctl(IOCTL_STATUS, &argument);
+		if (error < 0)
+			return error;
+		return argument.size;
+	}
+
+	ssize_t enumerate_threads(pid_t tgid, pid_t *tid_buffer, size_t buffer_size)
+	{
+		ioctl_enumeration argument { tgid, reinterpret_cast<addr_t>(tid_buffer), buffer_size, 0 };
+		int error = ::send_ioctl(IOCTL_STATUS, &argument);
+		if (error < 0)
+			return error;
+		return argument.size;
+	}
+
+	int suspension_reason(pid_t tid)
+	{
+		ioctl_flag argument { tid, 0 };
+		int error = ::send_ioctl(IOCTL_SUSPEND_REASON, &argument);
+		if (error < 0)
+			return error;
+		return argument.value;
+	}
+
+	int read_memory(pid_t tgid, addr_t address, unsigned char *buffer, size_t size)
+	{
+		ioctl_cpy argument { tgid, address, reinterpret_cast<addr_t>(buffer), size };
+		return ::send_ioctl(IOCTL_READ_MEMORY, &argument);
+	}
+
+	int write_memory(pid_t tgid, addr_t address, const unsigned char *buffer, size_t size)
+	{
+		ioctl_cpy argument { tgid, address, reinterpret_cast<addr_t>(buffer), size };
+		return ::send_ioctl(IOCTL_WRITE_MEMORY, &argument);
+	}
+
+	ssize_t read_registers(pid_t tid, int request_type, unsigned char *buffer, size_t size)
+	{
+		ioctl_cpy argument { tid, static_cast<addr_t>(request_type), reinterpret_cast<addr_t>(buffer), size };
+		int error = ::send_ioctl(IOCTL_READ_REGISTERS, &argument);
+		if (error < 0)
+			return error;
+		return argument.size;
+	}
+
+	int write_registers(pid_t tid, int request_type, const unsigned char *buffer, size_t size)
+	{
+		ioctl_cpy argument { tid, static_cast<addr_t>(request_type), reinterpret_cast<addr_t>(buffer), size };
+		return ::send_ioctl(IOCTL_READ_REGISTERS, &argument);
+	}
+
+	int read_auxv(pid_t tid, unsigned char *buffer, size_t size)
+	{
+		ioctl_cpy argument { tid, 0, reinterpret_cast<addr_t>(buffer), size };
+		return ::send_ioctl(IOCTL_READ_AUXV, &argument);
+	}
+
+	int cancel_signal(pid_t tid)
+	{
+		ioctl_tid_or_tgid argument { tid, ioctl_tid_or_tgid::TID };
+		return ::send_ioctl(IOCTL_CANCEL_SIGNAL, &argument);
+	}
+}

--- a/clients/plutonium-dbg.h
+++ b/clients/plutonium-dbg.h
@@ -1,0 +1,40 @@
+#include <stdbool.h>
+#include "../module/common.h"
+
+/* Allow users to specify custom function prefixes */
+
+#ifndef PLUTONIUM_DBG_PREFIX
+	#define PLUTONIUM_DBG_PREFIX plutonium_
+#endif
+
+#define PLUTONIUM_DBG_TOKEN_PASTE_IMPL(prefix, token) prefix##token
+#define PLUTONIUM_DBG_TOKEN_PASTE(prefix, token) PLUTONIUM_DBG_TOKEN_PASTE_IMPL(prefix, token)
+#define PLUTONIUM_DBG_NAME(token) PLUTONIUM_DBG_TOKEN_PASTE(PLUTONIUM_DBG_PREFIX, token)
+
+
+/* Interface */
+
+int PLUTONIUM_DBG_NAME(open_debugger)(void);
+void PLUTONIUM_DBG_NAME(close_debugger)(int fd);
+
+int PLUTONIUM_DBG_NAME(continue_thread)(int fd, pid_t tid);
+int PLUTONIUM_DBG_NAME(continue_process)(int fd, pid_t tgid);
+int PLUTONIUM_DBG_NAME(suspend_thread)(int fd, pid_t tid);
+int PLUTONIUM_DBG_NAME(suspend_process)(int fd, pid_t tgid);
+int PLUTONIUM_DBG_NAME(install_breakpoint)(int fd, pid_t tgid, addr_t address);
+int PLUTONIUM_DBG_NAME(remove_breakpoint)(int fd, pid_t tgid, addr_t address);
+int PLUTONIUM_DBG_NAME(thread_set_stepping)(int fd, pid_t tid, bool step);
+int PLUTONIUM_DBG_NAME(set_event_mask)(int fd, pid_t tgid, int mask);
+ssize_t PLUTONIUM_DBG_NAME(wait)(int fd, struct ioctl_event *event_buffer, size_t buffer_size);
+ssize_t PLUTONIUM_DBG_NAME(wait_for)(int fd, pid_t tid, struct ioctl_event *event_buffer, size_t buffer_size);
+ssize_t PLUTONIUM_DBG_NAME(events)(int fd, struct ioctl_event *event_buffer, size_t buffer_size);
+ssize_t PLUTONIUM_DBG_NAME(status)(int fd, pid_t *tid_buffer, size_t buffer_size);
+ssize_t PLUTONIUM_DBG_NAME(enumerate_threads)(int fd, pid_t tgid, pid_t *tid_buffer, size_t buffer_size);
+int PLUTONIUM_DBG_NAME(suspension_reason)(int fd, pid_t tid);
+int PLUTONIUM_DBG_NAME(read_memory)(int fd, pid_t tgid, addr_t address, unsigned char *buffer, size_t size);
+int PLUTONIUM_DBG_NAME(write_memory)(int fd, pid_t tgid, addr_t address, const unsigned char *buffer, size_t size);
+ssize_t PLUTONIUM_DBG_NAME(read_registers)(int fd, pid_t tid, int request_type, unsigned char *buffer, size_t size);
+int PLUTONIUM_DBG_NAME(write_registers)(int fd, pid_t tid, int request_type, const unsigned char *buffer, size_t size);
+int PLUTONIUM_DBG_NAME(read_auxv)(int fd, pid_t tid, unsigned char *buffer, size_t size);
+int PLUTONIUM_DBG_NAME(cancel_signal)(int fd, pid_t tid);
+

--- a/clients/plutonium-dbg.hpp
+++ b/clients/plutonium-dbg.hpp
@@ -1,0 +1,37 @@
+#ifndef PLUTONIUM_DBG_NS
+	#define PLUTONIUM_DBG_NS plutonium_dbg
+#endif
+
+#ifndef PLUTONIUM_DBG_PATH
+	#define PLUTONIUM_DBG_PATH "/dev/debugging"
+#endif
+
+extern "C"
+{
+    #include "../module/common.h"
+    typedef struct ioctl_event ioctl_event;
+}
+
+namespace PLUTONIUM_DBG_NS
+{
+	int continue_thread(pid_t tid);
+	int continue_process(pid_t tgid);
+	int suspend_thread(pid_t tid);
+	int suspend_process(pid_t tgid);
+	int install_breakpoint(pid_t tgid, addr_t address);
+	int remove_breakpoint(pid_t tgid, addr_t address);
+	int thread_set_stepping(pid_t tid, bool step);
+	int set_event_mask(pid_t tgid, int mask);
+	ssize_t wait(ioctl_event *event_buffer, size_t buffer_size);
+	ssize_t wait_for(pid_t tid, ioctl_event *event_buffer, size_t buffer_size);
+	ssize_t events(ioctl_event *event_buffer, size_t buffer_size);
+	ssize_t status(pid_t *tid_buffer, size_t buffer_size);
+	ssize_t enumerate_threads(pid_t tgid, pid_t *tid_buffer, size_t buffer_size);
+	int suspension_reason(pid_t tid);
+	int read_memory(pid_t tgid, addr_t address, unsigned char *buffer, size_t size);
+	int write_memory(pid_t tgid, addr_t address, const unsigned char *buffer, size_t size);
+	ssize_t read_registers(pid_t tid, int request_type, unsigned char *buffer, size_t size);
+	int write_registers(pid_t tid, int request_type, const unsigned char *buffer, size_t size);
+	int read_auxv(pid_t tid, unsigned char *buffer, size_t size);
+	int cancel_signal(pid_t tid);
+}

--- a/clients/plutonium_dbg.py
+++ b/clients/plutonium_dbg.py
@@ -95,7 +95,7 @@ class commands:
 
 # Actual client
 class debugger:
-    # Constants (see types.h)
+    # Constants (see common.h)
     NOT_SUSPENDED          = 0
     SUSPEND_EXPLICIT       = 1
     SUSPEND_ON_BREAK       = 2

--- a/module/common.h
+++ b/module/common.h
@@ -1,0 +1,194 @@
+#ifndef PLUTONIUM_DBG_COMMON_H
+#define PLUTONIUM_DBG_COMMON_H
+
+/*
+ * This file is intended for use by both user-space and kernel-space code.
+ * Language bindings should feel free to include this file to obtain necessary
+ * struct layouts and constant values and to extract the IOCTL command IDs.
+ * Please make sure that changes do not break anything in either mode!
+ * Note that throughout plutonium-dbg, we use "TGID" to describe the ID of a
+ * full user-space process (this value is called TGID in kernel-space, but is
+ * generally called PID in user-space), and "TID" to describe the ID of a
+ * user-space thread (this is what the kernel refers to as a PID, but user-space
+ * calls this the TID, see e.g. man 2 gettid).
+ * Data structures and constants only used in module code (especially those that
+ * pull in kernel headers for anything except trivial types like pid_t) should
+ * go in the types.h header, not here.
+ */
+
+#ifdef __KERNEL__
+	#include <linux/fs.h>
+	#include <linux/types.h>
+#else
+	#include <sys/ioctl.h>
+	#include <sys/param.h>
+	#include <sys/types.h>
+#endif
+
+
+/* Basic types */
+
+/**
+ * addr_t - Any address in memory
+ */
+typedef unsigned long addr_t;
+
+/**
+ * event_data - Additional data for a debugger event
+ * @suspension_reason: On EVENT_SUSPEND, contains one of the SUSPEND_ constants
+ *                     indicating the reason why a thread was suspended.
+ * @exit_code:         On EVENT_EXIT, this member holds the exit code.
+ * @signal:            The signal number for EVENT_SIGNAL.
+ * @clone_data:        Flags to clone() and the created TID for EVENT_CLONE.
+ * @exec_data:         Previous TID and the new filename for EVENT_EXEC.
+ */
+union event_data {
+	int suspension_reason; /* EVENT_SUSPEND */
+	int exit_code;         /* EVENT_EXIT */
+	int signal;            /* EVENT_SIGNAL */
+
+	/* EVENT_CLONE */
+	struct {
+		pid_t         new_task_tid;
+		unsigned long clone_flags;
+	} clone_data;
+
+	/* EVENT_EXEC */
+	struct {
+		pid_t calling_tid;
+		char  filename[NAME_MAX + 1];
+	} exec_data;
+};
+
+
+/* Constants */
+
+/** Suspension reasons */
+#define NOT_SUSPENDED          0
+#define SUSPEND_EXPLICIT       1
+#define SUSPEND_ON_BREAK       2
+#define SUSPEND_ON_SINGLE_STEP 3
+#define SUSPEND_ON_EXIT        4
+#define SUSPEND_ON_CLONE       5
+#define SUSPEND_ON_EXEC        6
+#define SUSPEND_ON_SIGNAL      7
+
+/** Event types */
+#define EVENT_SUSPEND     (1 << 0)
+#define EVENT_EXIT        (1 << 1)
+#define EVENT_CLONE       (1 << 2)
+#define EVENT_EXEC        (1 << 3)
+#define EVENT_SIGNAL      (1 << 4)
+
+
+/* Communication-only types (i.e. arguments to IOCTL) */
+
+/**
+ * ioctl_tid_or_tgid
+ * @id:   TID or TGID
+ * @type: Indicates the type of the ID
+ */
+struct ioctl_tid_or_tgid {
+	pid_t              id;
+	enum { TID, TGID } type;
+};
+
+/**
+ * ioctl_enumeration
+ * @target:    Target process. Whether this has any meaning depends on the IOCTL used.
+ * @buffer:    Buffer of items.
+ * @size:      Size of the buffer (in number of items). In the response, indicates how many items were written to the buffer.
+ * @available: Number of suspended threads currently available.
+ *
+ * If the response size is smaller than the available size, query again with a larger buffer.
+ * The type (and size) of an item is defined by the call this type is used for.
+ */
+struct ioctl_enumeration {
+	pid_t  target;
+	addr_t buffer;
+	size_t size;
+	size_t available;
+};
+
+/**
+ * ioctl_breakpoint_identifier
+ * @target:  TGID of the target process
+ * @address: Address of the breakpoint
+ */
+struct ioctl_breakpoint_identifier {
+	pid_t  target;
+	addr_t address;
+};
+
+/**
+ * ioctl_cpy
+ * @target:  TID or TGID of the target
+ * @which:   Address at which to begin copying (for memory) or type of the register set (for registers, usually NT_PRSTATUS = 1)
+ * @buffer:  Pointer to userspace buffer
+ * @size:    Size of the buffer that will be copied (register requests set this to the size of the full set)
+ */
+struct ioctl_cpy {
+	pid_t  target;
+	addr_t which;
+	addr_t buffer;
+	size_t size;
+};
+
+/**
+ * ioctl_flag
+ * @target: TID or TGID of the target
+ * @value:  Value of the flag
+ */
+struct ioctl_flag {
+	pid_t target;
+	int   value;
+};
+
+/**
+ * ioctl_argument
+ * Holds any of the ioctl argument types
+ */
+union ioctl_argument {
+	struct ioctl_tid_or_tgid           arg_id;
+	struct ioctl_enumeration           arg_enumeration;
+	struct ioctl_breakpoint_identifier arg_breakpoint;
+	struct ioctl_cpy                   arg_cpy;
+	struct ioctl_flag                  arg_flag;
+};
+
+/**
+ * ioctl_event
+ * Holds an event for the IOCTL buffer
+ */
+struct ioctl_event {
+	int              event_id;
+	pid_t            victim_tid;
+	union event_data data;
+};
+
+
+/* IOCTL codes */
+
+#define IOCTL_CODE '@'
+
+#define IOCTL_CONTINUE           _IOW(IOCTL_CODE,  0, struct ioctl_tid_or_tgid)
+#define IOCTL_SUSPEND            _IOW(IOCTL_CODE,  1, struct ioctl_tid_or_tgid)
+#define IOCTL_INSTALL_BREAKPOINT _IOW(IOCTL_CODE, 10, struct ioctl_breakpoint_identifier)
+#define IOCTL_REMOVE_BREAKPOINT  _IOW(IOCTL_CODE, 11, struct ioctl_breakpoint_identifier)
+#define IOCTL_SET_STEP           _IOW(IOCTL_CODE, 20, struct ioctl_flag)
+#define IOCTL_SET_EVENT_MASK     _IOW(IOCTL_CODE, 30, struct ioctl_flag)
+#define IOCTL_CANCEL_SIGNAL      _IOW(IOCTL_CODE, 40, struct ioctl_tid_or_tgid)
+
+#define IOCTL_WAIT               _IOWR(IOCTL_CODE,  0, struct ioctl_enumeration)
+#define IOCTL_WAIT_FOR           _IOWR(IOCTL_CODE,  1, struct ioctl_enumeration)
+#define IOCTL_EVENTS             _IOWR(IOCTL_CODE,  2, struct ioctl_enumeration)
+#define IOCTL_STATUS             _IOWR(IOCTL_CODE, 10, struct ioctl_enumeration)
+#define IOCTL_ENUMERATE_THREADS  _IOWR(IOCTL_CODE, 11, struct ioctl_enumeration)
+#define IOCTL_SUSPEND_REASON     _IOWR(IOCTL_CODE, 12, struct ioctl_flag)
+#define IOCTL_READ_MEMORY        _IOWR(IOCTL_CODE, 20, struct ioctl_cpy)
+#define IOCTL_WRITE_MEMORY       _IOWR(IOCTL_CODE, 21, struct ioctl_cpy)
+#define IOCTL_READ_AUXV          _IOWR(IOCTL_CODE, 22, struct ioctl_cpy)
+#define IOCTL_READ_REGISTERS     _IOWR(IOCTL_CODE, 30, struct ioctl_cpy)
+#define IOCTL_WRITE_REGISTERS    _IOWR(IOCTL_CODE, 31, struct ioctl_cpy)
+
+#endif /* PLUTONIUM_DBG_COMMON_H */

--- a/module/plutonium-dbg.c
+++ b/module/plutonium-dbg.c
@@ -1575,7 +1575,7 @@ static int read_auxv(pid_t tid, size_t size, char __user *uptr)
 	if (mm == NULL)
 		cleanup_and_return(-EACCES, put_task_struct(task));
 
-	/* Copy contents of auxv to userspace if the buffer is large enough) */
+	/* Copy contents of auxv to userspace if the buffer is large enough */
 	if (size < AT_VECTOR_SIZE * sizeof(void *))
 		cleanup_and_return(-EINVAL, mmput(mm), put_task_struct(task));
 
@@ -1987,28 +1987,6 @@ int __dump_event_queue(pid_t filter, pid_t debugger_tgid, struct ioctl_enumerati
 
 
 /* Communications */
-
-#define IOCTL_CODE '@'
-
-#define IOCTL_CONTINUE           _IOW(IOCTL_CODE,  0, struct ioctl_tid_or_tgid)
-#define IOCTL_SUSPEND            _IOW(IOCTL_CODE,  1, struct ioctl_tid_or_tgid)
-#define IOCTL_INSTALL_BREAKPOINT _IOW(IOCTL_CODE, 10, struct ioctl_breakpoint_identifier)
-#define IOCTL_REMOVE_BREAKPOINT  _IOW(IOCTL_CODE, 11, struct ioctl_breakpoint_identifier)
-#define IOCTL_SET_STEP           _IOW(IOCTL_CODE, 20, struct ioctl_flag)
-#define IOCTL_SET_EVENT_MASK     _IOW(IOCTL_CODE, 30, struct ioctl_flag)
-#define IOCTL_CANCEL_SIGNAL      _IOW(IOCTL_CODE, 40, struct ioctl_tid_or_tgid)
-
-#define IOCTL_WAIT               _IOWR(IOCTL_CODE,  0, struct ioctl_enumeration)
-#define IOCTL_WAIT_FOR           _IOWR(IOCTL_CODE,  1, struct ioctl_enumeration)
-#define IOCTL_EVENTS             _IOWR(IOCTL_CODE,  2, struct ioctl_enumeration)
-#define IOCTL_STATUS             _IOWR(IOCTL_CODE, 10, struct ioctl_enumeration)
-#define IOCTL_ENUMERATE_THREADS  _IOWR(IOCTL_CODE, 11, struct ioctl_enumeration)
-#define IOCTL_SUSPEND_REASON     _IOWR(IOCTL_CODE, 12, struct ioctl_flag)
-#define IOCTL_READ_MEMORY        _IOWR(IOCTL_CODE, 20, struct ioctl_cpy)
-#define IOCTL_WRITE_MEMORY       _IOWR(IOCTL_CODE, 21, struct ioctl_cpy)
-#define IOCTL_READ_AUXV          _IOWR(IOCTL_CODE, 22, struct ioctl_cpy)
-#define IOCTL_READ_REGISTERS     _IOWR(IOCTL_CODE, 30, struct ioctl_cpy)
-#define IOCTL_WRITE_REGISTERS    _IOWR(IOCTL_CODE, 31, struct ioctl_cpy)
 
 /**
  * on_ioctl - handles an incoming IOCTL


### PR DESCRIPTION
Writing `ioctl(...)` by hand is pretty tedious...

These commits:

- Separate `types.h` into `common.h` (which is usable from userspace) and `types.h` (which is not)
- Add bindings for C (`clients/plutonium-dbg.{c,h}`) and C++ (`clients/plutonium-dbg.{cpp,hpp}`)
- Move the IOCTL command definitions into `common.h` so we don't need to recalculate them in userspace.